### PR TITLE
Fix debian packaging

### DIFF
--- a/buildPkg.sh
+++ b/buildPkg.sh
@@ -4,7 +4,7 @@ pdir=`dirname $0`
 pdir=`readlink -f "$pdir"`
 #set -x
 config=package.yaml
-version="$1.0"
+version="$1"
 if [ "$version" = "" ] ; then
   version=`date '+%Y%m%d'`
 fi

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@
 #
 # check https://nfpm.goreleaser.com/configuration for detailed usage
 #
-name: "Sail_Instrument-plugin"
+name: "avnav-sailinstrument-plugin"
 arch: "all"
 platform: "linux"
 version: "202204"
@@ -10,7 +10,7 @@ keep_version: true
 section: "default"
 priority: "extra"
 depends:
-- avnav
+- avnav (>=20220426)
 maintainer: "Klaus D. Schmidt <kdschmidt@bluewin.ch>"
 description: |
   AvNav plugin to show a sailsteer display and Laylines on the map


### PR DESCRIPTION
Hi @kdschmidt1 ,

leider #1 wurde aus meiner Sicht nicht ganz korrekt umgesetzt. Die Packages für AvNav  haben ein bestimmtes Schema: "avnav-<name>-plugin". Was dann auch von avnav-update-plugin entsprechend honoriert wird.
PR löst das. 
Darüber hinaus enthält klein fix in buildPkg.sh

Gruß
free-x

P.S. Habe Package erzeugt. Darf ich in "Daily" Repository übernehmen?

